### PR TITLE
Make ClusterRenderer exchangable

### DIFF
--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
@@ -72,10 +72,14 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
      *
      * @param googleMap the map instance where markers will be rendered
      */
-    public ClusterManager(@NonNull Context context, @NonNull GoogleMap googleMap) {
+    public ClusterManager(
+            @NonNull Context context,
+            @NonNull GoogleMap googleMap,
+            @NonNull ClusterRenderer<T> clusterRenderer
+    ) {
         checkNotNull(context);
         mGoogleMap = checkNotNull(googleMap);
-        mRenderer = new ClusterRenderer<>(context, googleMap);
+        mRenderer = checkNotNull(clusterRenderer);
         mQuadTree = new QuadTree<>(QUAD_TREE_BUCKET_CAPACITY);
     }
 

--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterRenderer.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterRenderer.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static net.sharewire.googlemapsclustering.Preconditions.checkNotNull;
 
-class ClusterRenderer<T extends ClusterItem> implements GoogleMap.OnMarkerClickListener {
+public class ClusterRenderer<T extends ClusterItem> implements GoogleMap.OnMarkerClickListener {
 
     private static final int BACKGROUND_MARKER_Z_INDEX = 0;
 
@@ -38,7 +38,7 @@ class ClusterRenderer<T extends ClusterItem> implements GoogleMap.OnMarkerClickL
 
     private ClusterManager.Callbacks<T> mCallbacks;
 
-    ClusterRenderer(@NonNull Context context, @NonNull GoogleMap googleMap) {
+    public ClusterRenderer(@NonNull Context context, @NonNull GoogleMap googleMap) {
         mGoogleMap = googleMap;
         mGoogleMap.setOnMarkerClickListener(this);
         mIconGenerator = new DefaultIconGenerator<>(context);

--- a/sample/src/main/java/com/sharewire/googlemapsclustering/sample/MapsActivity.java
+++ b/sample/src/main/java/com/sharewire/googlemapsclustering/sample/MapsActivity.java
@@ -14,6 +14,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 import net.sharewire.googlemapsclustering.Cluster;
 import net.sharewire.googlemapsclustering.ClusterManager;
+import net.sharewire.googlemapsclustering.ClusterRenderer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,12 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
             }
         });
 
-        ClusterManager<SampleClusterItem> clusterManager = new ClusterManager<>(this, googleMap);
+        ClusterRenderer<SampleClusterItem> clusterRenderer = new ClusterRenderer<>(this, googleMap);
+        ClusterManager<SampleClusterItem> clusterManager = new ClusterManager<>(
+                this,
+                googleMap,
+                clusterRenderer
+        );
         clusterManager.setCallbacks(new ClusterManager.Callbacks<SampleClusterItem>() {
             @Override
             public boolean onClusterClick(@NonNull Cluster<SampleClusterItem> cluster) {


### PR DESCRIPTION
In my sideproject I  wanted to exchange the renderer to change how tag's are set and the animation. So I thought sharing this is a good idea. 

Another way of archiving this would be by defaulting to the `ClusterRenderer` and having a setter that makes it possible to exchange it later on.

You are more then welcome to give some thoughts on that.