### PR TITLE
Handling 180/-180 overlap

### DIFF
--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
@@ -166,7 +166,15 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
         long endX = (long) ((endLongitude + 180.0) / stepLongitude) + 1;
         long endY = (long) ((90.0 - endLatitude) / stepLatitude) + 1;
 
-        for (long tileX = startX; tileX <= endX; tileX++) {
+        // Handling 180/-180 overlap
+        if(startX > endX) {
+            endX += tileCount;
+        }
+
+        for (long x = startX; x <= endX; x++) {
+            // keep tileX in [0; tileCount) range
+            long tileX = x % tileCount;
+
             for (long tileY = startY; tileY <= endY; tileY++) {
                 double north = 90.0 - tileY * stepLatitude;
                 double west = tileX * stepLongitude - 180.0;


### PR DESCRIPTION
Hi!
We've found out that you ClusterManager removes all the markers from the map when camera bounds include 180'th meridian, coz this situation is not properly handled. You can reproduce it by adding points around 180/-180 to your `MapActivity::onMapReady`
```
        clusterItems.add(new SampleClusterItem(new LatLng(1, 179)));
        clusterItems.add(new SampleClusterItem(new LatLng(2, -179)));
```
I've added naive WO.