### PR TITLE
Split ClusterManager.Callbacks interface into 2 separate interfaces

### DIFF
--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
@@ -48,6 +48,7 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
      *
      * @param <T> the type of an item managed by {@link ClusterManager}.
      */
+    @Deprecated
     public interface Callbacks<T extends ClusterItem> {
         /**
          * Called when a marker representing a cluster has been clicked.
@@ -68,6 +69,40 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
          * to move to the marker and an info window to appear.
          */
         boolean onClusterItemClick(@NonNull T clusterItem);
+    }
+
+    /**
+     * Defines a signature for a method that is called when a cluster is clicked.
+     *
+     * @param <T> the type of an item managed by {@link ClusterManager}.
+     */
+    public interface ClusterClickCallback<T extends ClusterItem> {
+        /**
+         * Called when a marker representing a cluster has been clicked.
+         *
+         * @param cluster the cluster that has been clicked
+         * @return <code>true</code> if the listener has consumed the event (i.e., the default behavior should not occur);
+         * <code>false</code> otherwise (i.e., the default behavior should occur). The default behavior is for the camera
+         * to move to the marker and an info window to appear.
+         */
+        boolean onClick(@NonNull Cluster<T> cluster);
+    }
+
+    /**
+     * Defines a signature for a method that is called when a cluster item is clicked.
+     *
+     * @param <T> the type of an item managed by {@link ClusterManager}.
+     */
+    public interface ClusterItemClickCallback<T extends ClusterItem> {
+        /**
+         * Called when a marker representing a cluster item has been clicked.
+         *
+         * @param clusterItem the cluster item that has been clicked
+         * @return <code>true</code> if the listener has consumed the event (i.e., the default behavior should not occur);
+         * <code>false</code> otherwise (i.e., the default behavior should occur). The default behavior is for the camera
+         * to move to the marker and an info window to appear.
+         */
+        boolean onClick(@NonNull T clusterItem);
     }
 
     /**
@@ -100,8 +135,45 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
      * @param callbacks the callback that's invoked when a cluster or an individual item is clicked.
      *                  To unset the callback, use <code>null</code>.
      */
-    public void setCallbacks(@Nullable Callbacks<T> callbacks) {
-        mRenderer.setCallbacks(callbacks);
+    @Deprecated
+    public void setCallbacks(@Nullable final Callbacks<T> callbacks) {
+        if (callbacks == null) {
+            mRenderer.setClusterClickCallback(null);
+            mRenderer.setClusterItemClickCallback(null);
+        } else {
+            mRenderer.setClusterClickCallback(new ClusterClickCallback<T>() {
+                @Override
+                public boolean onClick(@NonNull Cluster<T> cluster) {
+                    return callbacks.onClusterClick(cluster);
+                }
+            });
+            mRenderer.setClusterItemClickCallback(new ClusterItemClickCallback<T>() {
+                @Override
+                public boolean onClick(@NonNull T clusterItem) {
+                    return callbacks.onClusterItemClick(clusterItem);
+                }
+            });
+        }
+    }
+
+    /**
+     * Sets a callback that's invoked when a cluster is clicked.
+     *
+     * @param callback the callback that's invoked when a cluster is clicked.
+     *                  To unset the callback, use <code>null</code>.
+     */
+    public void setClusterClickCallback(@Nullable ClusterClickCallback<T> callback) {
+        mRenderer.setClusterClickCallback(callback);
+    }
+
+    /**
+     * Sets a callback that's invoked when a cluster item is clicked.
+     *
+     * @param callback the callback that's invoked when an individual item is clicked.
+     *                  To unset the callback, use <code>null</code>.
+     */
+    public void setClusterItemClickCallback(@Nullable ClusterItemClickCallback<T> callback) {
+        mRenderer.setClusterItemClickCallback(callback);
     }
 
     /**

--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterRenderer.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterRenderer.java
@@ -36,7 +36,8 @@ class ClusterRenderer<T extends ClusterItem> implements GoogleMap.OnMarkerClickL
 
     private IconGenerator<T> mIconGenerator;
 
-    private ClusterManager.Callbacks<T> mCallbacks;
+    private ClusterManager.ClusterClickCallback<T> mClusterClickCallback;
+    private ClusterManager.ClusterItemClickCallback<T> mClusterItemClickCallback;
 
     ClusterRenderer(@NonNull Context context, @NonNull GoogleMap googleMap) {
         mGoogleMap = googleMap;
@@ -53,20 +54,22 @@ class ClusterRenderer<T extends ClusterItem> implements GoogleMap.OnMarkerClickL
             //noinspection ConstantConditions
             List<T> clusterItems = cluster.getItems();
 
-            if (mCallbacks != null) {
-                if (clusterItems.size() > 1) {
-                    return mCallbacks.onClusterClick(cluster);
-                } else {
-                    return mCallbacks.onClusterItemClick(clusterItems.get(0));
-                }
+            if (clusterItems.size() > 1 && mClusterClickCallback != null) {
+                return mClusterClickCallback.onClick(cluster);
+            } else if (mClusterItemClickCallback != null) {
+                return mClusterItemClickCallback.onClick(clusterItems.get(0));
             }
         }
 
         return false;
     }
 
-    void setCallbacks(@Nullable ClusterManager.Callbacks<T> listener) {
-        mCallbacks = listener;
+    void setClusterClickCallback(@Nullable ClusterManager.ClusterClickCallback<T> listener) {
+        mClusterClickCallback = listener;
+    }
+
+    void setClusterItemClickCallback(@Nullable ClusterManager.ClusterItemClickCallback<T> listener) {
+        mClusterItemClickCallback = listener;
     }
 
     void setIconGenerator(@NonNull IconGenerator<T> iconGenerator) {

--- a/sample/src/main/java/com/sharewire/googlemapsclustering/sample/MapsActivity.java
+++ b/sample/src/main/java/com/sharewire/googlemapsclustering/sample/MapsActivity.java
@@ -44,15 +44,16 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         });
 
         ClusterManager<SampleClusterItem> clusterManager = new ClusterManager<>(this, googleMap);
-        clusterManager.setCallbacks(new ClusterManager.Callbacks<SampleClusterItem>() {
+        clusterManager.setClusterClickCallback(new ClusterManager.ClusterClickCallback<SampleClusterItem>() {
             @Override
-            public boolean onClusterClick(@NonNull Cluster<SampleClusterItem> cluster) {
+            public boolean onClick(@NonNull Cluster<SampleClusterItem> cluster) {
                 Log.d(TAG, "onClusterClick");
                 return false;
             }
-
+        });
+        clusterManager.setClusterItemClickCallback(new ClusterManager.ClusterItemClickCallback<SampleClusterItem>() {
             @Override
-            public boolean onClusterItemClick(@NonNull SampleClusterItem clusterItem) {
+            public boolean onClick(@NonNull SampleClusterItem clusterItem) {
                 Log.d(TAG, "onClusterItemClick");
                 return false;
             }


### PR DESCRIPTION
Split ClusterManager.Callbacks interface into 2 separate interfaces to make a good use of SAM-conversion.