### PR TITLE
Fix the java.util.ConcurrentModificationException

### DIFF
--- a/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
+++ b/library/src/main/java/net/sharewire/googlemapsclustering/ClusterManager.java
@@ -214,8 +214,8 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
         @Override
         protected Void doInBackground(Void... params) {
             mQuadTree.clear();
-            for (T clusterItem : mClusterItems) {
-                mQuadTree.insert(clusterItem);
+            for (int i = 0; i < mClusterItems.size(); i++) {
+                mQuadTree.insert(mClusterItems.get(i));
             }
             return null;
         }


### PR DESCRIPTION
Fix the following error when screen rotate while quad tree is building:
```
java.util.ConcurrentModificationException
at java.util.ArrayList$Itr.next(ArrayList.java:831)
at net.sharewire.googlemapsclustering.ClusterManager$QuadTreeTask.doInBackground(ClusterManager.java:241)
at net.sharewire.googlemapsclustering.ClusterManager$QuadTreeTask.doInBackground(ClusterManager.java:227)
```